### PR TITLE
Add a member listener for OAuth join requests

### DIFF
--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -1,5 +1,8 @@
 import { Client, Guild, Member } from "eris";
-import { roleToAdd, roleTriggers } from "../util/config";
+
+import { roleToAdd } from "../util/config";
+import { hasSomeTrigger, updateMemberRoles } from "../util/common";
+import { RoleAction, RoleSource } from "../util/types";
 
 export default async (client: Client, guild: Guild, member: Member) => {
   if (guild.id !== process.env.DISCORD_GUILD_ID) return;
@@ -7,15 +10,10 @@ export default async (client: Client, guild: Guild, member: Member) => {
   if (member.bot) return;
 
   const roles = member.roles.slice();
-  const roleIndex = roles.indexOf(roleToAdd);
 
-  if (roles.some(r => roleTriggers.includes(r)) && roleIndex < 0) {
+  if (hasSomeTrigger(roles)) {
     roles.push(roleToAdd);
   }
 
-  if (roles.length !== member.roles.length) {
-    await member.edit({ roles }, `Role was added. (OAuth)`);
-
-    console.log(`[${new Date().toUTCString()}] Role ${roleToAdd} was added for ${member.username}.`);
-  }
+  updateMemberRoles(member, roles, RoleAction.ADDED, RoleSource.OAUTH);
 }

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -1,0 +1,21 @@
+import { Client, Guild, Member } from "eris";
+import { roleToAdd, roleTriggers } from "../util/config";
+
+export default async (client: Client, guild: Guild, member: Member) => {
+  if (guild.id !== process.env.DISCORD_GUILD_ID) return;
+
+  if (member.bot) return;
+
+  const roles = member.roles.slice();
+  const roleIndex = roles.indexOf(roleToAdd);
+
+  if (roles.some(r => roleTriggers.includes(r)) && roleIndex < 0) {
+    roles.push(roleToAdd);
+  }
+
+  if (roles.length !== member.roles.length) {
+    await member.edit({ roles }, `Role was added. (OAuth)`);
+
+    console.log(`[${new Date().toUTCString()}] Role ${roleToAdd} was added for ${member.username}.`);
+  }
+}

--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -36,10 +36,10 @@ export default async (client: Client, guild: Guild, member: Member) => {
   }
 
   if (roles.length !== member.roles.length) {
-    await member.edit({ roles });
+    const reason = `Role was ${action}`;
 
-    if (action) {
-      console.log(`[${new Date().toUTCString()}] Role ${roleToAdd} was ${action} for ${member.username}.`);
-    }
+    await member.edit({ roles }, `${reason}. (Gateway)`);
+    
+    console.log(`[${new Date().toUTCString()}] Role ${roleToAdd} was ${action} for ${member.username}.`);
   }
 }

--- a/src/events/guildMemberUpdate.ts
+++ b/src/events/guildMemberUpdate.ts
@@ -1,5 +1,8 @@
 import { Client, Guild, Member } from "eris";
-import { extraRoles, roleToAdd, roleTriggers } from "../util/config";
+
+import { extraRoles, roleToAdd } from "../util/config";
+import { hasSomeTrigger, updateMemberRoles } from "../util/common";
+import { RoleAction, RoleSource } from "../util/types";
 
 export default async (client: Client, guild: Guild, member: Member) => {
   if (guild.id !== process.env.DISCORD_GUILD_ID) return;
@@ -9,17 +12,17 @@ export default async (client: Client, guild: Guild, member: Member) => {
   const roles = member.roles.slice();
   const roleIndex = roles.indexOf(roleToAdd);
 
-  let action: 'added' | 'removed' | null = null;
+  let action: RoleAction = null;
 
-  if (roles.some(r => roleTriggers.includes(r))) {
+  if (hasSomeTrigger(roles)) {
     if (roleIndex < 0) {
       roles.push(roleToAdd);
-      action = 'added';
+      action = RoleAction.ADDED;
     }
   } else {
     if (roles.includes(roleToAdd)) {
       roles.splice(roleIndex, 1);
-      action = 'removed';
+      action = RoleAction.REMOVED;
     }
 
     /**
@@ -35,11 +38,5 @@ export default async (client: Client, guild: Guild, member: Member) => {
     }
   }
 
-  if (roles.length !== member.roles.length) {
-    const reason = `Role was ${action}`;
-
-    await member.edit({ roles }, `${reason}. (Gateway)`);
-    
-    console.log(`[${new Date().toUTCString()}] Role ${roleToAdd} was ${action} for ${member.username}.`);
-  }
+  updateMemberRoles(member, roles, action, RoleSource.GATEWAY);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ let dotenvPath = path.join(process.cwd(), '.env');
 if (path.parse(process.cwd()).name === 'dist') dotenvPath = path.join(process.cwd(), '..', '.env');
 dotenv.config({ path: dotenvPath });
 
+import guildMemberAdd from './events/guildMemberAdd.js';
 import guildMemberUpdateEvent from './events/guildMemberUpdate.js';
 import readyEvent from './events/ready.js';
 
@@ -15,6 +16,7 @@ const client = new Client(process.env.DISCORD_BOT_TOKEN, {
   autoreconnect: true
 });
 
+client.on('guildMemberAdd', guildMemberAdd.bind(null, client));
 client.on('guildMemberUpdate', guildMemberUpdateEvent.bind(null, client));
 client.on('ready', readyEvent.bind(null, client));
 

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -1,0 +1,18 @@
+import { Member } from "eris";
+
+import { RoleAction, RoleSource } from "./types";
+import { roleTriggers } from "./config";
+
+export async function updateMemberRoles(member: Member, roles: string[], action: RoleAction, source: RoleSource): Promise<boolean> {
+  if (roles.length === member.roles.length) return false;
+
+  const reason = `Role was ${action}`;
+
+  await member.edit({ roles }, `${reason}. [${source}]`);
+
+  console.log(`[${new Date().toUTCString()}] ${reason} for ${member.username} (${member.id}). [${source}]`);
+
+  return true;
+}
+
+export const hasSomeTrigger = (roles: string[]) => roles.some(role => roleTriggers.includes(role));

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,0 +1,9 @@
+export enum RoleAction {
+  ADDED = 'added',
+  REMOVED = 'removed'
+}
+
+export enum RoleSource {
+  OAUTH = 'OAuth',
+  GATEWAY = 'Gateway'
+}


### PR DESCRIPTION
The added event is to target members added to the server with the [OAuth endpoint](https://discord.dev/resources/guild#add-guild-member) by supporter integrations.

Code was refactored to share methods with common code and audit reasons were given source context.

*Despite the intended fix here, members given the associated role via OAuth will continue to not show in the audit log. Which also means any assoicated properties share the bugged behaviour.*